### PR TITLE
Add "pout" as an alias to the "pouting face" emoji

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -354,6 +354,7 @@
   , "description": "pouting face"
   , "aliases": [
       "rage"
+    , "pout"
     ]
   , "tags": [
       "angry"


### PR DESCRIPTION
The use of the term "rage" is not the same semantically, though the Apple implementation of "pouting face" is essentially the "angry face" plus color red. However, other implementations have more "pouting"-like visages, and so use of "pout" would be helpful.